### PR TITLE
Add .shallowClone and .deepClone api convenience aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ npm install node-v8-clone
 ### Usage:
 
 ```javascript
-var clone = require('node-v8-clone').clone;
+var clone = require('node-v8-clone');
+var shallowClone = clone.shallowClone;
+var deepClone = clone.deepClone;
 var a = { x: { y: {} } };
 
-// deep clone
-var b = clone(a, true);
+var b = deepClone(a);
 a === b // false
 a.x === b.x // false
 a.x.y === b.x.y // false
 
-// shallow clone
-var c = clone(a, false);
+var c = shallowClone(a);
 a === c // false
 a.x === c.x // true
 a.x.y === c.x.y // true

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -115,9 +115,17 @@ Cloner.prototype._noop = function(cloner, value) {};
 var cloner_shallow = new Cloner();
 var cloner_deep = new Cloner(true);
 
-module.exports.clone = function clone(value, deep) {
-  if (deep) {
+module.exports =
+{ clone: function clone(value, deep) {
+    if (deep) {
+      return cloner_deep.clone(value);
+    }
+    return cloner_shallow.clone(value);
+  }
+, deepClone: function deepClone(value) {
     return cloner_deep.clone(value);
   }
-  return cloner_shallow.clone(value);
+, shallowClone: function shallowClone(value) {
+    return cloner_shallow.clone(value);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-v8-clone",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "The most convenient and accurate cloner for node.js. It's also very fast in some cases (benchmarks inside).",
   "main": "lib/clone.js",
   "scripts": {


### PR DESCRIPTION
This pull request adds api shortcuts `deepClone` and `shallowClone` to circumvent the [api Boolean trap](http://ariya.ofilabs.com/2011/08/hall-of-api-shame-boolean-trap.html) problem.
